### PR TITLE
⭐️ Support Detents for Page Sheet for Improved Bottom Sheet UX

### DIFF
--- a/ios/src_library/React Native/RCTModalView/RCTModalView.swift
+++ b/ios/src_library/React Native/RCTModalView/RCTModalView.swift
@@ -141,7 +141,19 @@ class RCTModalView: UIView {
              .fullScreen,
              .overFullScreen:
           
+          // https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller
+          // Provides better support for the popular Bottom Sheet modal UX.
+          if (style is .pagesheet) {
+            if #available(iOS 15.0, *) {
+              if let sheet = nav.sheetPresentationController {
+                  nav.title = "Some Custom Title"
+                  sheet.detents = [.medium(), .large()]
+              }
+            }
+          }
+        
           self._modalPresentationStyle = style;
+        
           #if DEBUG
           print("RCTModalView, modalPresentationStyle didSet: \(style.stringDescription())");
           #endif


### PR DESCRIPTION
Proposal to include this new behavior in iOS 15 to make bottom sheets. 

This is pseudocode, just seems like the correct place to extend the behavior. 

The parent API would also need additional prop changes to support this.

For achieving UIs that look like this: <image src="https://miro.medium.com/max/1400/1*DSv96RYS7-38LBw8xT2hxw.png" />